### PR TITLE
Fix string error in unet_inference contrast log warning

### DIFF
--- a/CNNectome/inference/unet_inference.py
+++ b/CNNectome/inference/unet_inference.py
@@ -102,7 +102,7 @@ def get_contrast_adjustment(rf: zarr.hierarchy.Group,
             logging.warning(
                 ("min_sc and max_sc not specified and contrastAdjustment not found in attributes of {0:}, will "
                  "continue with default contrast (min {1:}, max{2:}").format(
-                    os.path.join(rf, raw_ds), min_sc, max_sc
+                    os.path.join(rf.store.dir_path(), raw_ds), min_sc, max_sc
                 )
             )
 


### PR DESCRIPTION
I hit this error in formatting the log warning when I didn't provide `min_sc` and `max_sc` as inputs. I was expecting it to warn me, and then move on using some default choices, but instead the formatting error in the warning breaks the script.

The problem is that os.path.join() will only accept str, bytes or os.PathLike object, not a zarr group. 

To get a string path from the zarr group, we can use `rf.store.dir_path()` instead of just `rf`. That is the suggestion in this PR.

```python-traceback
File ~/...CNNectome/CNNectome/inference/unet_inference.py in get_contrast_adjustment(rf, raw_ds)
     102            logging.warning(
     103                ("min_sc and max_sc not specified and contrastAdjustment not found in attributes of {0:}, will "
     104                 "continue with default contrast (min {1:}, max{2:}").format(
---> 105                    os.path.join(rf.store.dir_path(), raw_ds), min_sc, max_sc
     106                )
     107            )
---> os.path.join(rf, raw_ds), min_sc, max_sc

TypeError: expected str, bytes of os.Pathlike object, not Group
```
